### PR TITLE
Replace named_scope with scope

### DIFF
--- a/lib/active_olap.rb
+++ b/lib/active_olap.rb
@@ -5,7 +5,7 @@ module ActiveOLAP
     self.send(:extend, ClassMethods)
     self.send(:extend, Utils)
     
-    self.named_scope :olap_drilldown, lambda { |hash| self.olap_drilldown_finder_options(hash) }    
+    self.scope :olap_drilldown, lambda { |hash| self.olap_drilldown_finder_options(hash) }    
     
     self.cattr_accessor :active_olap_dimensions, :active_olap_aggregates
     self.active_olap_dimensions = {}


### PR DESCRIPTION
- Replace is needed because:

```
/Users/administrator/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activerecord-3.2.22/lib/active_record/dynamic_matchers.rb:55:in `method_missing': undefined method `named_scope' for #<Class:0x007fcc85bf3c78> (NoMethodError)
    from /Users/administrator/apps/admin_pci/vendor/cache/git/active_olap/lib/active_olap.rb:8:in `enable_active_olap'
    from /Users/administrator/apps/admin_pci/app/models/olap_payment_transaction.rb:9:in `<class:OlapPaymentTransaction>'
```
